### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,8 @@
     "test",
     "testing"
   ],
-
   "author": "Conrad Zimmerman <me@conradz.com>",
   "license": "BSD",
-
   "repository": {
     "type": "git",
     "url": "https://github.com/conradz/grunt-sauce-tap.git"
@@ -22,21 +20,17 @@
   "bugs": {
     "url": "https://github.com/conradz/grunt-sauce-tap/issues"
   },
-
   "main": "Gruntfile.js",
   "scripts": {
     "test": "grunt test"
   },
-
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
-
   "dependencies": {
     "sauce-tap-runner": "~0.1.0",
     "async": "~0.2.9"
   },
-
   "devDependencies": {
     "grunt-cli": "*",
     "grunt": "~0.4.1"


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
